### PR TITLE
Datacat 136

### DIFF
--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -33,8 +33,6 @@ def create_column_request_payload(asset):
         #Next asset, we don't need to reset count_order to 0
         create_column_request_payload.count_order = 1
         create_column_request_payload.current_asset_name = asset.entity_name
-
-    print(create_column_request_payload.count_order)
     return {
         "typeName": "Column",
         "attributes": {

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -23,10 +23,18 @@ def get_attribute_qualified_name(asset, level):
 
 def create_column_request_payload(asset):
     # Faking static variable behaviour to preserve column's order
-    if not hasattr(create_column_request_payload, "count_order"):
+    if not hasattr(create_column_request_payload, "count_order") and not hasattr(create_column_request_payload, "current_asset_name"):
         create_column_request_payload.count_order = 0
-    create_column_request_payload.count_order += 1
+        create_column_request_payload.current_asset_name = asset.entity_name
 
+    if create_column_request_payload.current_asset_name == asset.entity_name:
+        create_column_request_payload.count_order += 1
+    else:
+        #Next asset, we don't need to reset count_order to 0
+        create_column_request_payload.count_order = 1
+        create_column_request_payload.current_asset_name = asset.entity_name
+
+    print(create_column_request_payload.count_order)
     return {
         "typeName": "Column",
         "attributes": {

--- a/create_atlan_columns.py
+++ b/create_atlan_columns.py
@@ -63,7 +63,7 @@ def create_atlan_columns(database_name,
         columns.append(col)
 
     distinct_columns = set()
-
+    count_columns_asset = 0
     columns = [col for col in columns if col not in distinct_columns and (distinct_columns.add(col) or True)]
 
     logger.debug("Preparing API request to delete columns no longer mentioned in csv file")
@@ -71,6 +71,8 @@ def create_atlan_columns(database_name,
         entities = {column.entity_name: [] for column in columns}
         for column in columns:
             entities[column.entity_name].append(column.column_name)
+            if column.entity_name == table.entity_name:
+                count_columns_asset += 1
         for entity in entities:
             e = Table(entity_name=entity, database_name=database_name, schema_name=schema_name)
             asset_info_guid = get_asset_guid_by_qualified_name(e.get_qualified_name(), e.get_atlan_type_name())
@@ -82,7 +84,7 @@ def create_atlan_columns(database_name,
                     delete_asset(existing_columns[existing_column])
                     logger.info("'{}' Deleted successfully".format(existing_column))
     create_assets(columns, "createColumns")
-    table.set_column_count(len(columns))
+    table.set_column_count(count_columns_asset)
     create_assets([table], "createTables")
 
 


### PR DESCRIPTION
[DATACAT-136] : Asset's columns number and columns order
Correcting asset's columns number by adding a check for the current asset name, same for columns order 


[DATACAT-136]: https://jira-glc.atlassian.net/browse/DATACAT-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ