### PR TITLE
DATACAT-65

### DIFF
--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -6,7 +6,7 @@ from atlanapi.atlanutils import AtlanApiRequest
 from atlanapi.detach_classification import detach_classification
 from constants import CLASSIFICATION
 from exception.EnvVariableNotFound import EnvVariableNotFound
-from model import ColumnLineage
+from model import ColumnLineage, TableLineage
 
 logger = logging.getLogger('main_logger')
 
@@ -20,7 +20,7 @@ headers = {
 
 
 def attach_classification(assets):
-    assets_with_classification = [asset for asset in assets if not isinstance(asset, ColumnLineage) and asset.classification and asset.classification in CLASSIFICATION]
+    assets_with_classification = [asset for asset in assets if not isinstance(asset, ColumnLineage) and not isinstance(asset, TableLineage) and asset.classification and asset.classification in CLASSIFICATION]
     if not len(assets_with_classification):
         logger.info("No classification")
         return

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -6,6 +6,7 @@ from atlanapi.atlanutils import AtlanApiRequest
 from atlanapi.detach_classification import detach_classification
 from constants import CLASSIFICATION
 from exception.EnvVariableNotFound import EnvVariableNotFound
+from model import ColumnLineage
 
 logger = logging.getLogger('main_logger')
 
@@ -19,7 +20,7 @@ headers = {
 
 
 def attach_classification(assets):
-    assets_with_classification = [asset for asset in assets if asset.classification and asset.classification in CLASSIFICATION]
+    assets_with_classification = [asset for asset in assets if not isinstance(asset, ColumnLineage) and asset.classification and asset.classification in CLASSIFICATION]
     if not len(assets_with_classification):
         logger.info("No classification")
         return

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -1,0 +1,36 @@
+import json
+import logging
+
+from atlanapi.ApiConfig import create_api_config
+from atlanapi.atlanutils import AtlanApiRequest
+from constants import CLASSIFICATION
+from exception.EnvVariableNotFound import EnvVariableNotFound
+from model import TableLineage, ColumnLineage
+
+logger = logging.getLogger('main_logger')
+
+api_conf = create_api_config()
+
+authorization = 'Bearer {}'.format(api_conf.api_token)
+headers = {
+    'Authorization': authorization,
+    'Content-Type': 'application/json'
+}
+
+
+def attach_classification(assets):
+    assets_with_classification = [asset for asset in assets if asset.classification and asset.classification in CLASSIFICATION]
+    if not len(assets_with_classification):
+        logger.info("No classification")
+        return
+    try:
+        payload_for_bulk = map(lambda el: el.get_classification_payload_for_bulk_mode(), assets_with_classification)
+        payload = json.dumps(list(payload_for_bulk))
+        attach_classification_url = 'https://{}/api/meta/entity/bulk/classification/displayName'.format(api_conf.instance)
+        atlan_api_request_object = AtlanApiRequest("POST", attach_classification_url, headers, payload)
+
+        atlan_api_request_object.send_atlan_request()
+
+    except EnvVariableNotFound as e:
+        logger.warning(e.message)
+        raise e

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -25,6 +25,7 @@ def attach_classification(assets):
         logger.info("No classification")
         return
     try:
+        logger.info("attaching classification in bulk mode")
         # Detach the classification from assets which have a valid classification to be updated
         detach_classification(assets_with_classification)
         payload_for_bulk = map(lambda el: el.get_classification_payload_for_bulk_mode(), assets_with_classification)

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -6,7 +6,7 @@ from atlanapi.atlanutils import AtlanApiRequest
 from atlanapi.detach_classification import detach_classification
 from constants import CLASSIFICATION
 from exception.EnvVariableNotFound import EnvVariableNotFound
-from model import ColumnLineage, TableLineage
+from model import Column
 
 logger = logging.getLogger('main_logger')
 
@@ -20,7 +20,7 @@ headers = {
 
 
 def attach_classification(assets):
-    assets_with_classification = [asset for asset in assets if not isinstance(asset, ColumnLineage) and not isinstance(asset, TableLineage) and asset.classification and asset.classification in CLASSIFICATION]
+    assets_with_classification = [asset for asset in assets if isinstance(Column, asset) and asset.classification and asset.classification in CLASSIFICATION]
     if not len(assets_with_classification):
         logger.info("No classification")
         return

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -20,12 +20,12 @@ headers = {
 
 def attach_classification(assets):
     assets_with_classification = [asset for asset in assets if asset.classification and asset.classification in CLASSIFICATION]
-    #Detach the classification from assets which have a valid classification to be updated
-    detach_classification(assets_with_classification)
     if not len(assets_with_classification):
         logger.info("No classification")
         return
     try:
+        # Detach the classification from assets which have a valid classification to be updated
+        detach_classification(assets_with_classification)
         payload_for_bulk = map(lambda el: el.get_classification_payload_for_bulk_mode(), assets_with_classification)
         payload = json.dumps(list(payload_for_bulk))
         attach_classification_url = 'https://{}/api/meta/entity/bulk/classification/displayName'.format(api_conf.instance)

--- a/atlanapi/attach_classification.py
+++ b/atlanapi/attach_classification.py
@@ -3,9 +3,9 @@ import logging
 
 from atlanapi.ApiConfig import create_api_config
 from atlanapi.atlanutils import AtlanApiRequest
+from atlanapi.detach_classification import detach_classification
 from constants import CLASSIFICATION
 from exception.EnvVariableNotFound import EnvVariableNotFound
-from model import TableLineage, ColumnLineage
 
 logger = logging.getLogger('main_logger')
 
@@ -20,6 +20,8 @@ headers = {
 
 def attach_classification(assets):
     assets_with_classification = [asset for asset in assets if asset.classification and asset.classification in CLASSIFICATION]
+    #Detach the classification from assets which have a valid classification to be updated
+    detach_classification(assets_with_classification)
     if not len(assets_with_classification):
         logger.info("No classification")
         return

--- a/atlanapi/createAsset.py
+++ b/atlanapi/createAsset.py
@@ -126,9 +126,9 @@ def create_assets(assets, tag):
 
         logger.debug("Creating Readme, linking glossary terms and linking classification...")
         attach_classification(assets)
+        link_term(assets)
         for asset in assets:
             create_readme(asset)
-            link_term(asset)
     except EnvVariableNotFound as e:
         logger.warning(e.message)
         raise e

--- a/atlanapi/createAsset.py
+++ b/atlanapi/createAsset.py
@@ -3,6 +3,7 @@ import json
 import os
 import time
 
+from atlanapi.attach_classification import attach_classification
 from atlanapi.searchAssets import get_asset_guid_by_qualified_name
 from atlanapi.ApiConfig import create_api_config
 from atlanapi.atlanutils import AtlanApiRequest
@@ -122,7 +123,8 @@ def create_assets(assets, tag):
         atlan_api_schema_request_object.send_atlan_request()
         time.sleep(1)
 
-        logger.debug("Creating Readme and linking glossary terms...")
+        logger.debug("Creating Readme, linking glossary terms and linking classification...")
+        attach_classification(assets)
         for asset in assets:
             create_readme(asset)
             link_term(asset)

--- a/atlanapi/detach_classification.py
+++ b/atlanapi/detach_classification.py
@@ -1,9 +1,9 @@
 import json
 import logging
+import functools
 
 from atlanapi.ApiConfig import create_api_config
 from atlanapi.atlanutils import AtlanApiRequest
-from exception.EnvVariableNotFound import EnvVariableNotFound
 
 logger = logging.getLogger('main_logger')
 
@@ -17,14 +17,10 @@ headers = {
 
 
 def detach_classification(assets):
-    try:
-        payload_for_bulk = map(lambda el: el.get_detach_classification_payload_for_bulk_mode(), assets)
-        payload = json.dumps(list(payload_for_bulk))
-        attach_classification_url = 'https://{}/api/meta/entity/bulk/setClassifications'.format(api_conf.instance)
-        atlan_api_request_object = AtlanApiRequest("POST", attach_classification_url, headers, payload)
+    list_of_payloads = list(map(lambda el: el.get_detach_classification_payload_for_bulk_mode(), assets))
+    payload = json.dumps({"guidHeaderMap": functools.reduce(lambda d1, d2: {**d1, **d2}, list_of_payloads)})
+    attach_classification_url = 'https://{}/api/meta/entity/bulk/setClassifications'.format(api_conf.instance)
+    atlan_api_request_object = AtlanApiRequest("POST", attach_classification_url, headers, payload)
 
-        atlan_api_request_object.send_atlan_request()
-
-    except EnvVariableNotFound as e:
-        logger.warning(e.message)
-        raise e
+    response = atlan_api_request_object.send_atlan_request()
+    response.content

--- a/atlanapi/detach_classification.py
+++ b/atlanapi/detach_classification.py
@@ -1,0 +1,35 @@
+import json
+import logging
+
+from atlanapi.ApiConfig import create_api_config
+from atlanapi.atlanutils import AtlanApiRequest
+from atlanapi.searchAssets import get_asset_guid_by_qualified_name
+
+logger = logging.getLogger('main_logger')
+
+api_conf = create_api_config()
+
+authorization = 'Bearer {}'.format(api_conf.api_token)
+headers = {
+    'Authorization': authorization,
+    'Content-Type': 'application/json'
+}
+
+def detach_classification(asset):
+    data = {
+        "guidHeaderMap": {
+            get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()): {
+                "guid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
+                "typeName": asset.get_atlan_type_name(),
+                "attributes": {
+                    "name": asset.get_asset_name(),
+                    "qualifiedName": asset.get_qualified_name(),
+                },
+                "classifications": []
+            }
+        }
+    }
+    payload = json.dumps(data)
+    url = 'https://{}/api/meta/entity/bulk/setClassifications'.format(api_conf.instance)
+    request_object = AtlanApiRequest("POST", url, headers, payload)
+    request_object.send_atlan_request()

--- a/atlanapi/detach_classification.py
+++ b/atlanapi/detach_classification.py
@@ -22,5 +22,4 @@ def detach_classification(assets):
     attach_classification_url = 'https://{}/api/meta/entity/bulk/setClassifications'.format(api_conf.instance)
     atlan_api_request_object = AtlanApiRequest("POST", attach_classification_url, headers, payload)
 
-    response = atlan_api_request_object.send_atlan_request()
-    response.content
+    atlan_api_request_object.send_atlan_request()

--- a/atlanapi/linkTerm.py
+++ b/atlanapi/linkTerm.py
@@ -4,6 +4,7 @@ import logging
 from atlanapi.ApiConfig import create_api_config
 from atlanapi.atlanutils import AtlanApiRequest
 from atlanapi.searchGlossaryTerms import get_glossary_term_guid_by_name
+from atlanapi.unlink_term import unlink_term
 from model import TableLineage, ColumnLineage
 
 logger = logging.getLogger('main_logger')
@@ -17,39 +18,19 @@ headers = {
 }
 
 
-def link_term(asset):
-    if isinstance(asset, ColumnLineage) or isinstance(asset, TableLineage) or not asset.term or not asset.glossary:
+def link_term(assets):
+    assets_with_terms = [asset for asset in assets if not isinstance(asset, ColumnLineage) or not isinstance(asset, TableLineage) or asset.term or asset.glossary]
+    if not assets_with_terms:
         return
     try:
-        term_guid = get_glossary_term_guid_by_name(asset.term, asset.glossary)
-        payload = json.dumps({
-            "entities":
-                [
-                    {
-                        "typeName": asset.get_atlan_type_name(),
-                        "attributes": {
-                            "name": asset.get_asset_name(),
-                            "qualifiedName": asset.get_qualified_name()
-                        },
-                        "relationshipAttributes": {
-                            "meanings": [
-                                {
-                                    "typeName": "AtlasGlossaryTerm",
-                                    "guid": term_guid
-                                }
-                            ]
-                        }
-                    }
-                ]
-            })
+        #Update all changes for linked terms
+        unlink_term(assets_with_terms)
+        payload_for_bulk_mode = map(lambda el: el.get_link_term_for_bulk_mode(), assets_with_terms)
+        payload = json.dumps({"entities": list(payload_for_bulk_mode)})
         link_to_term_url = 'https://{}/api/meta/entity/bulk#{}'.format(api_conf.instance, 'attachGlossaryTerm')
         atlan_api_request_object = AtlanApiRequest("POST", link_to_term_url, headers, payload)
 
         atlan_api_request_object.send_atlan_request()
-        logger.debug("Glossary term '{}' linked successfully to {} '{}'".format(
-            asset.term, asset.get_atlan_type_name(), asset.get_asset_name())
-        )
 
     except Exception as e:
-        logger.warning("Error while linking glossary term '{}' to {} '{}'. Glossary term must already exist in Atlan."
-                       .format(asset.term, asset.get_atlan_type_name(), asset.get_asset_name()))
+        logger.warning("Error while linking glossary terms")

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -211,18 +211,17 @@ def classification_request_payload(asset):
         "removePropagationsOnEntityDelete": True
     }
 
+
 def detach_classification_request_payload(asset):
     asset_guid = get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name())
     return {
-        "guidHeaderMap": {
-            asset_guid: {
-                "guid": asset_guid,
-                "typeName": asset.get_atlan_type_name(),
-                "attributes": {
-                    "name": "date",
-                    "qualifiedName": asset.get_qualified_name(),
-                },
-                "classifications": []
-            }
+        asset_guid: {
+            "guid": asset_guid,
+            "typeName": asset.get_atlan_type_name(),
+            "attributes": {
+                "name": "date",
+                "qualifiedName": asset.get_qualified_name(),
+            },
+            "classifications": []
         }
     }

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -203,7 +203,7 @@ def create_entity_lineage_request_payload(asset):
     }
 
 
-def classification_schema_request_payload(asset):
+def classification_request_payload(asset):
     return {
         "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
         "displayName": asset.classification,
@@ -211,20 +211,18 @@ def classification_schema_request_payload(asset):
         "removePropagationsOnEntityDelete": True
     }
 
-
-def classification_table_request_payload(asset):
+def detach_classification_request_payload(asset):
+    asset_guid = get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name())
     return {
-        "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
-        "displayName": asset.classification,
-        "propagate": True,
-        "removePropagationsOnEntityDelete": True
-    }
-
-
-def classification_column_request_payload(asset):
-    return {
-        "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
-        "displayName": asset.classification,
-        "propagate": True,
-        "removePropagationsOnEntityDelete": True
+        "guidHeaderMap": {
+            asset_guid: {
+                "guid": asset_guid,
+                "typeName": asset.get_atlan_type_name(),
+                "attributes": {
+                    "name": "date",
+                    "qualifiedName": asset.get_qualified_name(),
+                },
+                "classifications": []
+            }
+        }
     }

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -1,4 +1,6 @@
 import os
+
+from atlanapi.searchAssets import get_asset_guid_by_qualified_name
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, INTEGRATION_TYPE_REDSHIFT
 
 GET_CONNECTOR_NAME_INTEGRATION_TYPE = {
@@ -6,7 +8,6 @@ GET_CONNECTOR_NAME_INTEGRATION_TYPE = {
     INTEGRATION_TYPE_ATHENA: 'athena',
     INTEGRATION_TYPE_REDSHIFT: 'redshift'
 }
-
 
 """
 Looking for asset attribute database qualified name
@@ -17,20 +18,23 @@ Looking for asset attribute database qualified name
 - get_attribute_qualified_name(asset, 1) -> default/mongodb/database/schema
 - get_attribute_qualified_name(asset, 2) -> default/mongodb/database
 """
+
+
 def get_attribute_qualified_name(asset, level):
     return '/'.join(asset.get_qualified_name().split('/')[:-level])
 
 
 def create_column_request_payload(asset):
     # Faking static variable behaviour to preserve column's order
-    if not hasattr(create_column_request_payload, "count_order") and not hasattr(create_column_request_payload, "current_asset_name"):
+    if not hasattr(create_column_request_payload, "count_order") and not hasattr(create_column_request_payload,
+                                                                                 "current_asset_name"):
         create_column_request_payload.count_order = 0
         create_column_request_payload.current_asset_name = asset.entity_name
 
     if create_column_request_payload.current_asset_name == asset.entity_name:
         create_column_request_payload.count_order += 1
     else:
-        #Next asset, we don't need to reset count_order to 0
+        # Next asset, we don't need to reset count_order to 0
         create_column_request_payload.count_order = 1
         create_column_request_payload.current_asset_name = asset.entity_name
     return {
@@ -115,12 +119,14 @@ def create_column_lineage_request_payload(asset):
         _lineage_qualified_name = "{}/{}".format(asset.column.get_qualified_name(),
                                                  asset.lineage_full_qualified_name)
         _lineage_name = "{}-{} Transformation".format(asset.column.integration_type, asset.lineage_integration_type)
-        process_lineage_qualified_name = "{}/{}".format(get_attribute_qualified_name(asset.column, 1), os.path.split(asset.lineage_full_qualified_name)[0])
+        process_lineage_qualified_name = "{}/{}".format(get_attribute_qualified_name(asset.column, 1),
+                                                        os.path.split(asset.lineage_full_qualified_name)[0])
     else:
         _lineage_qualified_name = "{}/{}".format(asset.lineage_full_qualified_name,
                                                  asset.column.get_qualified_name())
         _lineage_name = "{}-{} Transformation".format(asset.lineage_integration_type, asset.column.integration_type)
-        process_lineage_qualified_name = "{}/{}".format(os.path.split(asset.lineage_full_qualified_name)[0], get_attribute_qualified_name(asset.column, 1))
+        process_lineage_qualified_name = "{}/{}".format(os.path.split(asset.lineage_full_qualified_name)[0],
+                                                        get_attribute_qualified_name(asset.column, 1))
 
     return {
         "typeName": "ColumnProcess",
@@ -194,4 +200,31 @@ def create_entity_lineage_request_payload(asset):
                 }
             ]
         }
+    }
+
+
+def classification_schema_request_payload(asset):
+    return {
+        "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
+        "displayName": asset.classification,
+        "propagate": True,
+        "removePropagationsOnEntityDelete": True
+    }
+
+
+def classification_table_request_payload(asset):
+    return {
+        "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
+        "displayName": asset.classification,
+        "propagate": True,
+        "removePropagationsOnEntityDelete": True
+    }
+
+
+def classification_column_request_payload(asset):
+    return {
+        "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
+        "displayName": asset.classification,
+        "propagate": True,
+        "removePropagationsOnEntityDelete": True
     }

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -208,7 +208,7 @@ def classification_request_payload(asset):
     return {
         "entityGuid": get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name()),
         "displayName": asset.classification,
-        "propagate": True,
+        "propagate": False,
         "removePropagationsOnEntityDelete": True
     }
 
@@ -220,7 +220,7 @@ def detach_classification_request_payload(asset):
             "guid": asset_guid,
             "typeName": asset.get_atlan_type_name(),
             "attributes": {
-                "name": "date",
+                "name": asset.get_asset_name(),
                 "qualifiedName": asset.get_qualified_name(),
             },
             "classifications": []

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -1,6 +1,7 @@
 import os
 
 from atlanapi.searchAssets import get_asset_guid_by_qualified_name
+from atlanapi.searchGlossaryTerms import get_glossary_term_guid_by_name
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, INTEGRATION_TYPE_REDSHIFT
 
 GET_CONNECTOR_NAME_INTEGRATION_TYPE = {
@@ -223,5 +224,39 @@ def detach_classification_request_payload(asset):
                 "qualifiedName": asset.get_qualified_name(),
             },
             "classifications": []
+        }
+    }
+
+
+def link_term_request_payload(asset):
+    term_guid = get_glossary_term_guid_by_name(asset.term, asset.glossary)
+    return {
+        "typeName": asset.get_atlan_type_name(),
+        "attributes": {
+            "name": asset.get_asset_name(),
+            "qualifiedName": asset.get_qualified_name()
+        },
+        "relationshipAttributes": {
+            "meanings": [
+                {
+                    "typeName": "AtlasGlossaryTerm",
+                    "guid": term_guid
+                }
+            ]
+        }
+    }
+
+
+def unlink_term_request_payload(asset):
+    asset_guid = get_asset_guid_by_qualified_name(asset.get_qualified_name(), asset.get_atlan_type_name())
+    return {
+        "guid": asset_guid,
+        "typeName": asset.get_atlan_type_name(),
+        "attributes": {
+            "name": asset.get_asset_name(),
+            "qualifiedName": asset.get_qualified_name()
+        },
+        "relationshipAttributes": {
+            "meanings": []
         }
     }

--- a/atlanapi/unlink_term.py
+++ b/atlanapi/unlink_term.py
@@ -1,0 +1,23 @@
+import json
+import logging
+
+from atlanapi.ApiConfig import create_api_config
+from atlanapi.atlanutils import AtlanApiRequest
+
+logger = logging.getLogger('main_logger')
+
+api_conf = create_api_config()
+
+authorization = 'Bearer {}'.format(api_conf.api_token)
+headers = {
+    'Authorization': authorization,
+    'Content-Type': 'application/json'
+}
+
+def unlink_term(assets):
+    payload_bulk_mode = map(lambda el: el.get_unlink_term_for_bulk_mode(), assets)
+    payload = json.dumps({"entities": list(payload_bulk_mode)})
+    unlink_term_url = 'https://{}/api/meta/entity/bulk'.format(api_conf.instance)
+    atlan_api_request_object = AtlanApiRequest("POST", unlink_term_url, headers, payload)
+
+    atlan_api_request_object.send_atlan_request()

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,6 @@
-BASE_PATH_ATLAN_DOCS = "/github/workspace/docs/datacatalog"
-# BASE_PATH_ATLAN_DOCS = "./docs/datacatalog"
-# BASE_PATH_ATLAN_DOCS = "./docs/sample/datacatalog"
+#BASE_PATH_ATLAN_DOCS = "/github/workspace/docs/datacatalog"
+#BASE_PATH_ATLAN_DOCS = "./../atlan/data-dlh-fct-client-metrics-lc-loader/datacatalog"
+BASE_PATH_ATLAN_DOCS = "./docs/sample/datacatalog"
 MANIFEST_FILE_NAME = "manifest.csv"
 
 INTEGRATION_TYPE_DYNAMO_DB = 'dynamodb'
@@ -14,3 +14,5 @@ ATHENA_CONN_QN = "default/athena"
 ATHENA_DATABASE_NAME = 'AwsDataCatalog'
 DYNAMO_DB_DATABASE_NAME = 'dynamo_db'
 REDSHIFT_DATABASE_NAME = 'dwhstats'
+
+CLASSIFICATION = ['PII', 'Protected', 'Private', 'Public']

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,6 @@
-#BASE_PATH_ATLAN_DOCS = "/github/workspace/docs/datacatalog"
+BASE_PATH_ATLAN_DOCS = "/github/workspace/docs/datacatalog"
 #BASE_PATH_ATLAN_DOCS = "./../atlan/data-dlh-fct-client-metrics-lc-loader/datacatalog"
-BASE_PATH_ATLAN_DOCS = "./docs/sample/datacatalog"
+#BASE_PATH_ATLAN_DOCS = "./docs/sample/datacatalog"
 MANIFEST_FILE_NAME = "manifest.csv"
 
 INTEGRATION_TYPE_DYNAMO_DB = 'dynamodb'

--- a/create_atlan_columns.py
+++ b/create_atlan_columns.py
@@ -17,7 +17,7 @@ from atlanapi.delete_asset import delete_asset
 from atlanapi.get_entity_columns import get_entity_columns
 from atlanapi.searchAssets import get_asset_guid_by_qualified_name
 from atlanapi.atlanutils import AtlanSourceFile
-from atlanapi.createAsset import create_assets
+from atlanapi.createAsset import create_assets, update_assets
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA
 from model import Column, Table
 
@@ -86,7 +86,7 @@ def create_atlan_columns(database_name,
                     logger.info("'{}' Deleted successfully".format(existing_column))
     create_assets(columns, "createColumns")
     table.set_column_count(count_columns_asset)
-    create_assets([table], "createTables")
+    update_assets([table], "createTables")
 
 
 if __name__ == '__main__':

--- a/create_atlan_columns.py
+++ b/create_atlan_columns.py
@@ -59,7 +59,8 @@ def create_atlan_columns(database_name,
                      description=row['Summary (Description)'],
                      readme=row['Readme'],
                      term=row['Term'].strip(),
-                     glossary=row['Glossary'].strip())
+                     glossary=row['Glossary'].strip(),
+                     classification=row['Classification'])
         columns.append(col)
 
     distinct_columns = set()

--- a/create_atlan_schema_and_entities.py
+++ b/create_atlan_schema_and_entities.py
@@ -37,7 +37,7 @@ def create_atlan_schema_and_entities(path_to_manifest, sep=","):
                           readme=row['Readme'],
                           term=row['Term'],
                           glossary=row['Glossary'],
-                          classification=row['Classification'],
+                          #classification=row['Classification'],
                           integration_type=row['Integration Type'])
             tables.append(table)
             # Create schema from entity row in case schema row is missing

--- a/create_atlan_schema_and_entities.py
+++ b/create_atlan_schema_and_entities.py
@@ -21,7 +21,6 @@ logger = logging.getLogger('main_logger')
 
 
 def create_atlan_schema_and_entities(path_to_manifest, sep=","):
-
     logger.info("Loading manifest...")
     source_data = AtlanSourceFile(path_to_manifest, sep)
     source_data.load_csv()
@@ -32,13 +31,14 @@ def create_atlan_schema_and_entities(path_to_manifest, sep=","):
     for index, row in source_data.assets_def.iterrows():
         if row['Table/Entity']:
             table = Table(entity_name=row['Table/Entity'],
-                            database_name=row['Database'],
-                            schema_name=row['Schema'],
-                            description=row['Summary (Description)'],
-                            readme=row['Readme'],
-                            term=row['Term'],
-                            glossary=row['Glossary'],
-                            integration_type=row['Integration Type'])
+                          database_name=row['Database'],
+                          schema_name=row['Schema'],
+                          description=row['Summary (Description)'],
+                          readme=row['Readme'],
+                          term=row['Term'],
+                          glossary=row['Glossary'],
+                          classification=row['Classification'],
+                          integration_type=row['Integration Type'])
             tables.append(table)
             # Create schema from entity row in case schema row is missing
             schema = Schema(database_name=row['Database'],
@@ -58,6 +58,7 @@ def create_atlan_schema_and_entities(path_to_manifest, sep=","):
                             readme=row['Readme'],
                             term=row['Term'],
                             glossary=row['Glossary'],
+                            #classification=row['Classification'],
                             integration_type=row['Integration Type'])
             schemas.append(schema)
     # Create asset's database if does not exist

--- a/create_atlan_schema_and_entities.py
+++ b/create_atlan_schema_and_entities.py
@@ -37,7 +37,6 @@ def create_atlan_schema_and_entities(path_to_manifest, sep=","):
                           readme=row['Readme'],
                           term=row['Term'],
                           glossary=row['Glossary'],
-                          #classification=row['Classification'],
                           integration_type=row['Integration Type'])
             tables.append(table)
             # Create schema from entity row in case schema row is missing
@@ -58,7 +57,6 @@ def create_atlan_schema_and_entities(path_to_manifest, sep=","):
                             readme=row['Readme'],
                             term=row['Term'],
                             glossary=row['Glossary'],
-                            #classification=row['Classification'],
                             integration_type=row['Integration Type'])
             schemas.append(schema)
     # Create asset's database if does not exist

--- a/model/column.py
+++ b/model/column.py
@@ -3,7 +3,7 @@ import os
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_column_request_payload
+from atlanapi.requests import create_column_request_payload, classification_column_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -22,7 +22,8 @@ class Column:
                  description=None,
                  readme=None,
                  term=None,
-                 glossary=None):
+                 glossary=None,
+                 classification=None):
         self.integration_type = integration_type.lower()
         self.database_name = database_name
         self.schema_name = schema_name
@@ -33,10 +34,11 @@ class Column:
         self.readme = readme
         self.term = term
         self.glossary = glossary
+        self.classification = classification
 
     def get_qualified_name(self):
         if self.integration_type == INTEGRATION_TYPE_DYNAMO_DB:
-            qualified_name = DYNAMODB_CONN_QN  + "/" + \
+            qualified_name = DYNAMODB_CONN_QN + "/" + \
                              get_database(self.integration_type) + "/{}/{}/{}"
         elif self.integration_type == INTEGRATION_TYPE_ATHENA:
             qualified_name = ATHENA_CONN_QN + "/" + get_atlan_athena_connection_id(self) + "/" + \
@@ -60,6 +62,9 @@ class Column:
 
     def get_creation_payload(self):
         raise Exception("Column are creating in bulk mode only")
+
+    def get_classification_payload_for_bulk_mode(self):
+        return classification_column_request_payload(self)
 
     def __eq__(self, other):
         if isinstance(other, Column):

--- a/model/column.py
+++ b/model/column.py
@@ -4,7 +4,7 @@ from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
 from atlanapi.requests import create_column_request_payload, classification_request_payload, \
-    detach_classification_request_payload
+    detach_classification_request_payload, link_term_request_payload, unlink_term_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -69,6 +69,12 @@ class Column:
 
     def get_detach_classification_payload_for_bulk_mode(self):
         return detach_classification_request_payload(self)
+
+    def get_link_term_for_bulk_mode(self):
+        return link_term_request_payload(self)
+
+    def get_unlink_term_for_bulk_mode(self):
+        return unlink_term_request_payload(self)
 
     def __eq__(self, other):
         if isinstance(other, Column):

--- a/model/column.py
+++ b/model/column.py
@@ -3,7 +3,8 @@ import os
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_column_request_payload, classification_column_request_payload
+from atlanapi.requests import create_column_request_payload, classification_request_payload, \
+    detach_classification_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -64,7 +65,10 @@ class Column:
         raise Exception("Column are creating in bulk mode only")
 
     def get_classification_payload_for_bulk_mode(self):
-        return classification_column_request_payload(self)
+        return classification_request_payload(self)
+
+    def get_detach_classification_payload_for_bulk_mode(self):
+        return detach_classification_request_payload(self)
 
     def __eq__(self, other):
         if isinstance(other, Column):

--- a/model/schema.py
+++ b/model/schema.py
@@ -3,14 +3,15 @@ from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
 from atlanapi.requests import create_schema_request_payload, classification_request_payload, \
-    detach_classification_request_payload
+    detach_classification_request_payload, link_term_request_payload, unlink_term_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
 
 @auto_str
 class Schema:
-    def __init__(self, database_name, schema_name, description=None, readme=None, term=None, glossary=None, classification=None,
+    def __init__(self, database_name, schema_name, description=None, readme=None, term=None, glossary=None,
+                 classification=None,
                  integration_type=INTEGRATION_TYPE_DYNAMO_DB):
         self.database_name = database_name
         self.schema_name = schema_name
@@ -59,3 +60,9 @@ class Schema:
 
     def get_detach_classification_payload_for_bulk_mode(self):
         return detach_classification_request_payload(self)
+
+    def get_link_term_for_bulk_mode(self):
+        return link_term_request_payload(self)
+
+    def get_unlink_term_for_bulk_mode(self):
+        return unlink_term_request_payload(self)

--- a/model/schema.py
+++ b/model/schema.py
@@ -2,14 +2,14 @@ import json
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_schema_request_payload
+from atlanapi.requests import create_schema_request_payload, classification_schema_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
 
 @auto_str
 class Schema:
-    def __init__(self, database_name, schema_name, description=None, readme=None, term=None, glossary=None,
+    def __init__(self, database_name, schema_name, description=None, readme=None, term=None, glossary=None, classification=None,
                  integration_type=INTEGRATION_TYPE_DYNAMO_DB):
         self.database_name = database_name
         self.schema_name = schema_name
@@ -17,6 +17,7 @@ class Schema:
         self.readme = readme
         self.term = term
         self.glossary = glossary
+        self.classification = classification
         self.integration_type = integration_type.lower()
 
     def get_qualified_name(self):
@@ -51,3 +52,6 @@ class Schema:
 
     def get_lineage_payload(self):
         raise Exception("Not implemented !")
+
+    def get_classification_payload_for_bulk_mode(self):
+        return classification_schema_request_payload(self)

--- a/model/schema.py
+++ b/model/schema.py
@@ -11,7 +11,6 @@ from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
 @auto_str
 class Schema:
     def __init__(self, database_name, schema_name, description=None, readme=None, term=None, glossary=None,
-                 classification=None,
                  integration_type=INTEGRATION_TYPE_DYNAMO_DB):
         self.database_name = database_name
         self.schema_name = schema_name
@@ -19,7 +18,6 @@ class Schema:
         self.readme = readme
         self.term = term
         self.glossary = glossary
-        self.classification = classification
         self.integration_type = integration_type.lower()
 
     def get_qualified_name(self):
@@ -54,12 +52,6 @@ class Schema:
 
     def get_lineage_payload(self):
         raise Exception("Not implemented !")
-
-    def get_classification_payload_for_bulk_mode(self):
-        return classification_request_payload(self)
-
-    def get_detach_classification_payload_for_bulk_mode(self):
-        return detach_classification_request_payload(self)
 
     def get_link_term_for_bulk_mode(self):
         return link_term_request_payload(self)

--- a/model/schema.py
+++ b/model/schema.py
@@ -2,7 +2,8 @@ import json
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_schema_request_payload, classification_schema_request_payload
+from atlanapi.requests import create_schema_request_payload, classification_request_payload, \
+    detach_classification_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -54,4 +55,7 @@ class Schema:
         raise Exception("Not implemented !")
 
     def get_classification_payload_for_bulk_mode(self):
-        return classification_schema_request_payload(self)
+        return classification_request_payload(self)
+
+    def get_detach_classification_payload_for_bulk_mode(self):
+        return detach_classification_request_payload(self)

--- a/model/table.py
+++ b/model/table.py
@@ -2,9 +2,9 @@ import json
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_table_request_payload
+from atlanapi.requests import create_table_request_payload, classification_table_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
-    INTEGRATION_TYPE_REDSHIFT,  REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
+    INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
 
 @auto_str
@@ -17,6 +17,7 @@ class Table:
                  readme=None,
                  term=None,
                  glossary=None,
+                 classification=None,
                  integration_type=INTEGRATION_TYPE_DYNAMO_DB,
                  column_count=None):
         self.entity_name = entity_name
@@ -26,6 +27,7 @@ class Table:
         self.readme = readme
         self.term = term
         self.glossary = glossary
+        self.classification = classification
         self.integration_type = integration_type.lower()
         self.column_count = column_count
 
@@ -63,6 +65,15 @@ class Table:
 
     def set_column_count(self, column_count):
         self.column_count = column_count
+
+    def classification_table_request_payload(self):
+        table_info = {"entities": [
+            classification_table_request_payload(self)
+        ]}
+        return json.dumps(table_info)
+
+    def get_classification_payload_for_bulk_mode(self):
+        return classification_table_request_payload(self)
 
     def __repr__(self):
         return "({},{},{},{})".format(

--- a/model/table.py
+++ b/model/table.py
@@ -2,7 +2,8 @@ import json
 from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
-from atlanapi.requests import create_table_request_payload, classification_table_request_payload
+from atlanapi.requests import create_table_request_payload, classification_request_payload, \
+    detach_classification_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -66,14 +67,11 @@ class Table:
     def set_column_count(self, column_count):
         self.column_count = column_count
 
-    def classification_table_request_payload(self):
-        table_info = {"entities": [
-            classification_table_request_payload(self)
-        ]}
-        return json.dumps(table_info)
-
     def get_classification_payload_for_bulk_mode(self):
-        return classification_table_request_payload(self)
+        return classification_request_payload(self)
+
+    def get_detach_classification_payload_for_bulk_mode(self):
+        return detach_classification_request_payload(self)
 
     def __repr__(self):
         return "({},{},{},{})".format(

--- a/model/table.py
+++ b/model/table.py
@@ -3,7 +3,7 @@ from annotation import auto_str
 from model import get_atlan_athena_connection_id, get_atlan_redshift_connection_id, get_database
 
 from atlanapi.requests import create_table_request_payload, classification_request_payload, \
-    detach_classification_request_payload
+    detach_classification_request_payload, link_term_request_payload, unlink_term_request_payload
 from constants import INTEGRATION_TYPE_DYNAMO_DB, INTEGRATION_TYPE_ATHENA, \
     INTEGRATION_TYPE_REDSHIFT, REDSHIFT_CONN_QN, DYNAMODB_CONN_QN, ATHENA_CONN_QN
 
@@ -72,6 +72,12 @@ class Table:
 
     def get_detach_classification_payload_for_bulk_mode(self):
         return detach_classification_request_payload(self)
+
+    def get_link_term_for_bulk_mode(self):
+        return link_term_request_payload(self)
+
+    def get_unlink_term_for_bulk_mode(self):
+        return unlink_term_request_payload(self)
 
     def __repr__(self):
         return "({},{},{},{})".format(

--- a/model/table.py
+++ b/model/table.py
@@ -18,7 +18,6 @@ class Table:
                  readme=None,
                  term=None,
                  glossary=None,
-                 classification=None,
                  integration_type=INTEGRATION_TYPE_DYNAMO_DB,
                  column_count=None):
         self.entity_name = entity_name
@@ -28,7 +27,6 @@ class Table:
         self.readme = readme
         self.term = term
         self.glossary = glossary
-        self.classification = classification
         self.integration_type = integration_type.lower()
         self.column_count = column_count
 
@@ -66,12 +64,6 @@ class Table:
 
     def set_column_count(self, column_count):
         self.column_count = column_count
-
-    def get_classification_payload_for_bulk_mode(self):
-        return classification_request_payload(self)
-
-    def get_detach_classification_payload_for_bulk_mode(self):
-        return detach_classification_request_payload(self)
 
     def get_link_term_for_bulk_mode(self):
         return link_term_request_payload(self)


### PR DESCRIPTION
Cette branche concerne les tickets : **DATACAT-65, DATACAT-139 & DLH-879**

**Gestion de la colonne classification :**

- Attachement de la classification à l'asset en mode bulk
- Détachement de la classification de l'asset en mode bulk

**Correction de la requête de lier le terme à l'asset**

- Utilisation du mode bulk : On crée un payload qui contient les payloads de chaque asset ayant un terme à lier, pour ensuite faire une requête API
- Délier les assets et leur terme, toujours en mode bulk

