### PR TITLE
Fix/fix dynamo integration

### DIFF
--- a/atlanapi/createAsset.py
+++ b/atlanapi/createAsset.py
@@ -122,9 +122,11 @@ def create_assets(assets, tag):
         payloads_for_bulk = map(lambda el: el.get_creation_payload_for_bulk_mode(), assets)
 
         payload = json.dumps({"entities": list(payloads_for_bulk)})
+        print(payload)
         schema_post_url = 'https://{}/api/meta/entity/bulk#{}'.format(api_conf.instance, tag)
         atlan_api_schema_request_object = AtlanApiRequest("POST", schema_post_url, headers, payload)
-        atlan_api_schema_request_object.send_atlan_request()
+        response = atlan_api_schema_request_object.send_atlan_request()
+        print(response)
         time.sleep(1)
 
         logger.debug("Creating Readme, linking glossary terms and linking classification...")

--- a/atlanapi/createAsset.py
+++ b/atlanapi/createAsset.py
@@ -122,11 +122,9 @@ def create_assets(assets, tag):
         payloads_for_bulk = map(lambda el: el.get_creation_payload_for_bulk_mode(), assets)
 
         payload = json.dumps({"entities": list(payloads_for_bulk)})
-        print(payload)
         schema_post_url = 'https://{}/api/meta/entity/bulk#{}'.format(api_conf.instance, tag)
         atlan_api_schema_request_object = AtlanApiRequest("POST", schema_post_url, headers, payload)
-        response = atlan_api_schema_request_object.send_atlan_request()
-        print(response)
+        atlan_api_schema_request_object.send_atlan_request()
         time.sleep(1)
 
         logger.debug("Creating Readme, linking glossary terms and linking classification...")

--- a/atlanapi/requests.py
+++ b/atlanapi/requests.py
@@ -101,17 +101,8 @@ def create_schema_request_payload(asset):
             "qualifiedName": asset.get_qualified_name(),
             "databaseName": asset.database_name,
             "description": asset.description,
-            "databaseQualifiedName": get_attribute_qualified_name(asset, 1),
             "connectorName": GET_CONNECTOR_NAME_INTEGRATION_TYPE[asset.integration_type],
             "connectionQualifiedName": get_attribute_qualified_name(asset, 2)
-        },
-        "relationshipAttributes": {
-            "database": {
-                "typeName": "Database",
-                "uniqueAttributes": {
-                    "qualifiedName": get_attribute_qualified_name(asset, 1)
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Correction de l'intégration Atlan V2 pour DynamoDB:


- Changement du connecteur de DynamoDB dans Atlan Vé : dynamodb/dynamodb.atlan.com -> dynamodb/dynamo-prod

- Changement du payload pour l'API au niveau de la création du schema
              * Ne créait pas l'assset schema car l'attribut du payload relationshipAttribute ne trouvait pas la bdd, qu'on ne crée plus 
                 via requête API